### PR TITLE
fix: No defined variable "posposter_srcter"

### DIFF
--- a/templates/theme-default/layouts/partials/components/c-video.html
+++ b/templates/theme-default/layouts/partials/components/c-video.html
@@ -19,7 +19,7 @@
 {{- $poster_src := false -}}
 {{- with $poster_asset -}}
   {{- with .src }}
-      {{- $posposter_srcter = . -}}
+      {{- $poster_src = . -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Think this is a typo. Changed it in BB already.

Reproduce error: maintain a poster image in a video component in Contentful. 
Fix: remove typo. 