### PR TITLE
Fix: remove commented out utils dump

### DIFF
--- a/templates/theme-default/layouts/partials/modules/m-footer.html
+++ b/templates/theme-default/layouts/partials/modules/m-footer.html
@@ -1,7 +1,6 @@
 {{- $globals := .globals -}}
 {{- $context := .context | default dict -}}
 
-{{/* {{ partial "utils/dump" $context }} */}}
 <footer class="m-footer">
   <div class="o-wrapper">
     <p class="c-paragraph">


### PR DESCRIPTION
This PR removes a line in m-footer that has been commented out and is for development purposes only. 