### PR TITLE
Feature: add table to rich text blocks

### DIFF
--- a/hugo-modules/core/utils/rich-text/blocks/table-cell.html
+++ b/hugo-modules/core/utils/rich-text/blocks/table-cell.html
@@ -1,0 +1,9 @@
+{{- $globals := .globals -}}
+{{- $context := .context -}}
+
+<td>
+  {{- partial "utils/rich-text/get-block" (dict
+    "context" $context
+    "globals" $globals
+  ) -}}
+</td>

--- a/hugo-modules/core/utils/rich-text/blocks/table-header-cell.html
+++ b/hugo-modules/core/utils/rich-text/blocks/table-header-cell.html
@@ -1,0 +1,9 @@
+{{- $globals := .globals -}}
+{{- $context := .context -}}
+
+<th>
+  {{- partial "utils/rich-text/get-block" (dict
+    "context" $context
+    "globals" $globals
+  ) -}}
+</th>

--- a/hugo-modules/core/utils/rich-text/blocks/table-row.html
+++ b/hugo-modules/core/utils/rich-text/blocks/table-row.html
@@ -1,0 +1,9 @@
+{{- $globals := .globals -}}
+{{- $context := .context -}}
+
+<tr>
+  {{- partial "utils/rich-text/get-block" (dict
+    "context" $context
+    "globals" $globals
+  ) -}}
+</tr>

--- a/hugo-modules/core/utils/rich-text/blocks/table.html
+++ b/hugo-modules/core/utils/rich-text/blocks/table.html
@@ -1,0 +1,9 @@
+{{- $globals := .globals -}}
+{{- $context := .context -}}
+
+<table>
+  {{- partial "utils/rich-text/get-block" (dict
+    "context" $context
+    "globals" $globals
+  ) -}}
+</table>


### PR DESCRIPTION
This PR adds table blocks to the rich text utils.

Context: Contentful now offers the possibility to add tables to the rich text field.
If added in Contentful the app crashes since it is searching for the the table.html (and the other files).


