### PR TITLE
fix(SEO): Use page title as default meta title

### DIFF
--- a/hugo-modules/core/utils/seo/private/get-data.html
+++ b/hugo-modules/core/utils/seo/private/get-data.html
@@ -94,6 +94,9 @@
 	1. Every pages: `Page title | Global site title`
 	2. Homepage: only `Global site title` */}}
 {{ $title := "" }}
+{{ with .Params.title }}
+	{{ $title = . }}
+{{ end }}
 {{ with $seo_params.title }}
 	{{ $title = . }}
 {{ end }}


### PR DESCRIPTION
The default page title is currently not used as meta title, instead only the optional title of the SEO params.