### PR TITLE
Fix: 404 page meta robots tag

### DIFF
--- a/hugo-modules/core/utils/seo/private/get-tags.html
+++ b/hugo-modules/core/utils/seo/private/get-tags.html
@@ -98,8 +98,9 @@
 {{ with $seo }}
   {{ $value := "noindex, nofollow" }}
   {{ $production := eq (getenv "HUGO_ENV") "production" }}
-  {{ $index := cond (eq .no_index true) "noindex" "index" }}
-  {{ $follow := cond (eq .no_follow true) "nofollow" "follow" }}
+  {{ $is_404 := eq $.Page.Kind "404" }}
+  {{ $index := cond (or (eq .no_index true) $is_404) "noindex" "index" }}
+  {{ $follow := cond (or (eq .no_follow true) $is_404) "nofollow" "follow" }}
 
   {{ if and $production }}
     {{ $value = (print $index ", " $follow) }}


### PR DESCRIPTION
This PR prevents enabling the meta robots tag on 404 pages even if the environment is set to production.