### PR TITLE
Fix: Use correct URL for share image

### DIFF
--- a/hugo-modules/core/README.md
+++ b/hugo-modules/core/README.md
@@ -2,7 +2,7 @@
 
 [Hugo](https://gohugo.io/) templates and utilities that support [Contentful](https://www.contentful.com/) and/or [Storybook](https://storybook.js.org/) projects.
 
-- [wekit-core](#wekit-core)
+- [WEKit core](#wekit-core)
   - [Utils](#utils)
     - [asset](#asset)
     - [svg/icon](#svgicon)
@@ -11,6 +11,7 @@
     - [console/error](#consoleerror)
     - [console/warn](#consolewarn)
     - [dump](#dump)
+    - [get-abs-url](#get-abs-url)
     - [get-category-name](#get-category-name)
     - [get-data](#get-data)
     - [get-page](#get-page)
@@ -28,6 +29,7 @@
   - [Layouts](#layouts)
     - [storybook](#storybook)
     - [robots.txt](#robotstxt)
+  - [Contributors](#contributors)
   - [Credits](#credits)
 
 ## Utils
@@ -35,7 +37,7 @@
 ### asset
 
 Render Contentful asset. Uses data from [cssg-plugin-assets](https://github.com/jungvonmatt/contentful-ssg/tree/main/packages/cssg-plugin-assets) if available.
-Uses `svg/icon` when the inline options is set and we got an svg, 
+Uses `svg/icon` when the inline options is set and we got an svg,
 *Template*
 
 ```
@@ -117,6 +119,16 @@ Dump variable as highlighted yaml.
 
 ```
 {{ partial "utils/dump" .context }}
+```
+
+### get-abs-url
+
+Returns an absolute URL with forced https prototol.
+
+*Template*
+
+```
+{{ partial "utils/get-abs-url" .url }}
 ```
 
 ### get-category-name

--- a/hugo-modules/core/utils/asset/image/img.html
+++ b/hugo-modules/core/utils/asset/image/img.html
@@ -55,7 +55,8 @@
     {{- end -}}
   {{- else -}}
     {{- with $url -}}
-      {{- $src := $params.src | default (cond (hasPrefix . "//") (print "https:" .) .) -}}
+      {{- $absUrl := partial "utils/get-abs-url" . -}}
+      {{- $src := $params.src | default $absUrl -}}
       <img src="{{- $src -}}" width="{{- $width -}}" height="{{- $height -}}" {{ $image_attributes }} alt="{{- $alt -}}"{{ with $params.preload }} fetchpriority="high"{{ end }}>
       {{/* Add preload hint here as we have no srcset available */}}
       {{- $preload_attr := (dict

--- a/hugo-modules/core/utils/get-abs-url.html
+++ b/hugo-modules/core/utils/get-abs-url.html
@@ -1,0 +1,18 @@
+{{/*
+  utils/get-abs-url
+  Returns an absolute URL with forced https prototol.
+
+  @returns Sring
+
+  @example - Go Template
+    {{ partial "utils/get-abs-url" .url }}
+*/}}
+{{ $url := . }}
+
+{{/* Creates an absolute URL based on the configured baseURL. */}}
+{{ $url = . | absURL }}
+
+{{/* Adds https prototcol if the url starts with // and is not localhost */}}
+{{ $url = cond (and (hasPrefix $url "//") (not (hasPrefix $url "//localhost"))) (print "https:" $url) $url }}
+
+{{ return $url }}

--- a/hugo-modules/core/utils/link.html
+++ b/hugo-modules/core/utils/link.html
@@ -9,7 +9,7 @@
 
 {{/* context is url */}}
 {{ if partialCached "utils/reflect/is-string" . . }}
-  {{ $href := cond (and (hasPrefix . "//") (not (hasPrefix . "//localhost")) ) (print "https:" . ) . }}
+  {{ $href := partial "utils/get-abs-url" . }}
   {{ $return = (dict "href" $href) }}
   {{/* Add target="_blank" and rel="noreferrer" for external links */}}
   {{ if (and (in . "//") (not (in . site.BaseURL))) }}

--- a/hugo-modules/core/utils/seo/private/get-data.html
+++ b/hugo-modules/core/utils/seo/private/get-data.html
@@ -133,11 +133,11 @@
 {{ $img := false }}
 
 {{ with $settings.default_share_image }}
-	{{ $img = .url }}
+	{{ $img = partial "utils/get-abs-url.html" .url }}
 {{ end }}
 
 {{ with $seo_params.share_image }}
-	{{ $img = .url }}
+	{{ $img = partial "utils/get-abs-url.html" .url }}
 {{ else }}
 	{{/* If no SEO IMAGE is set, we look for the .Params.images slice
 		and use the first one if it has an `image` key */}}
@@ -145,10 +145,10 @@
 		{{ with index . 0 }}
 			{{ if reflect.IsMap . }}
 				{{ with .image }}
-					{{ $img = .url }}
+					{{ $img = partial "utils/get-abs-url.html" .url }}
 				{{ end }}
 			{{ else }}
-				{{ $img = .url }}
+				{{ $img = partial "utils/get-abs-url.html" .url }}
 			{{ end }}
 		{{ end }}
 	{{ end }}

--- a/hugo-modules/core/utils/svg/parse.html
+++ b/hugo-modules/core/utils/svg/parse.html
@@ -54,7 +54,7 @@
   {{ end }}
 {{ end }}
 {{ with .url }}
-  {{ $src = cond (hasPrefix . "//") (print "https:" .) . }}
+  {{ $src := partial "utils/get-abs-url" . }}
   {{ with resources.GetRemote $src }}
     {{ $src = .RelPermalink }}
     {{ $source = .Content }}


### PR DESCRIPTION
This PR corrects the URL of the share image. 

By default the asset urls come from Contentful without prototcol – e.g.:
```
//images.ctfassets.net.../share_image.jpg
```

But the real absolute URL including prototol is needed.

Otherwise the image will be resolved like this:
```
https://www.yourdomain.com//images.ctfassets.net.../share_image.jpg
```

In addition, the code snippet was moved to a util because we already use the pattern (Hugo function absURL + protocol) in other places.