### PR TITLE
Do not throw on invalid Vimeo id, render hint instead

### DIFF
--- a/templates/app/config/_default/config.yaml
+++ b/templates/app/config/_default/config.yaml
@@ -7,6 +7,8 @@ disableHugoGeneratorInject: true
 enableRobotsTXT: true
 buildDrafts: true
 languageCode: en
+ignoreErrors:
+  - error-remote-getjson
 defaultContentLanguage: en
 defaultContentLanguageInSubdir: true
 sitemap:

--- a/templates/app/config/production/config.yaml
+++ b/templates/app/config/production/config.yaml
@@ -1,1 +1,3 @@
 buildDrafts: false
+ignoreErrors:
+  - error-remote-getjson

--- a/templates/theme-default/layouts/partials/components/c-video/embed-vimeo.html
+++ b/templates/theme-default/layouts/partials/components/c-video/embed-vimeo.html
@@ -63,10 +63,11 @@
   {{/* Build player url */}}
   {{- $url := print "https://player.vimeo.com/video/" $video_id "?" (delimit $query "&") -}}
 
-  {{/* Try to fetch thumbnail & title from vimeo oembed json */}}
+  {{/* Try getting thumbnail & title from Vimeo oEmbed endpoint */}}
   {{- $poster_src := "" -}}
+
   {{- with getJSON "https://vimeo.com/api/oembed.json?url=https://vimeo.com/"  $video_id }}
-    {{/* Try get with & height from oembed to scale the thumbnail */}}
+    {{/* Access width & height from Vimeo embedcode to scale the thumbnail */}}
     {{- $width := 0 -}}
     {{- $height := 0 -}}
     {{- $factor := 0 -}}
@@ -87,7 +88,11 @@
     {{- with .title -}}
       {{- $title = $title | default . -}}
     {{- end -}}
-  {{- end -}}
+  {{ else }}
+      {{/* Generate Embedcode failed, possibly due to invalid Vimeo source URL */}}
+      {{ warnf "Generating Vimeo embedcode failed" }}
+      <div>Generating Vimdeo embedcode failed. Please make sure to use a valid source URL.</div>
+  {{ end }}
 
   {{/* Generate srcdoc iframe placholder when autoplay is not enabled */}}
   {{- $srcdoc := false -}}


### PR DESCRIPTION
This prevents builds from throwing an error and failing on invalid Vimeo source URLs entered in the CMS. Instead, we render an error message to clearly indicate what went wrong. We achieve this by ignoring the Hugo error on GET ("error-remote-getjson") and adding a statement to the embed template. 