### PR TITLE
Include self-reference in hreflang tags

### DIFF
--- a/hugo-modules/core/utils/seo/private/get-tags.html
+++ b/hugo-modules/core/utils/seo/private/get-tags.html
@@ -38,7 +38,7 @@
 {{ end }}
 
 {{ with $seo.locale }}
-  {{ $c := dict "key" "locale" "value" .}}
+  {{ $c := dict "key" "locale" "value" . }}
   {{ $tags = $tags | append (partialCached "utils/seo/tag/og" $c $c) }}
 
   {{ $attr := dict "rel" "alternate" "href" $.Permalink "hreflang" . }}
@@ -52,7 +52,7 @@
     {{ $c := dict "name" "link" "attr" $attr }}
     {{ $tags = $tags | append $c }}
 
-    {{ $c2 := dict "key" "locale:alternate" "value" .code}}
+    {{ $c2 := dict "key" "locale:alternate" "value" .code }}
     {{ $tags = $tags | append (partialCached "utils/seo/tag/og" $c2 $c2) }}
   {{ end }}
 {{ end }}

--- a/hugo-modules/core/utils/seo/private/get-tags.html
+++ b/hugo-modules/core/utils/seo/private/get-tags.html
@@ -15,8 +15,6 @@
 
 {{ $seo := partial "utils/seo/private/get-data" $ }}
 
-
-
 {{ $tags := slice }}
 {{ with $seo.title }}
   {{ if not $config.disable_title_tag }}
@@ -42,16 +40,22 @@
 {{ with $seo.locale }}
   {{ $c := dict "key" "locale" "value" .}}
   {{ $tags = $tags | append (partialCached "utils/seo/tag/og" $c $c) }}
+
+  {{ $attr := dict "rel" "alternate" "href" $.Permalink "hreflang" . }}
+  {{ $c2 := dict "name" "link" "attr" $attr }}
+  {{ $tags = $tags | append $c2 }}
 {{ end }}
+
+{{ warnf $.Permalink }}
 
 {{ with $seo.translations }}
   {{ range . }}
-  {{ $attr := dict "rel" "alternate" "href" .permalink "hreflang" .code }}
-  {{ $c := dict "name" "link" "attr" $attr }}
-  {{ $tags = $tags | append $c }}
+    {{ $attr := dict "rel" "alternate" "href" .permalink "hreflang" .code }}
+    {{ $c := dict "name" "link" "attr" $attr }}
+    {{ $tags = $tags | append $c }}
 
-  {{ $c2 := dict "key" "locale:alternate" "value" .code}}
-  {{ $tags = $tags | append (partialCached "utils/seo/tag/og" $c2 $c2) }}
+    {{ $c2 := dict "key" "locale:alternate" "value" .code}}
+    {{ $tags = $tags | append (partialCached "utils/seo/tag/og" $c2 $c2) }}
   {{ end }}
 {{ end }}
 

--- a/hugo-modules/core/utils/seo/private/get-tags.html
+++ b/hugo-modules/core/utils/seo/private/get-tags.html
@@ -46,8 +46,6 @@
   {{ $tags = $tags | append $c2 }}
 {{ end }}
 
-{{ warnf $.Permalink }}
-
 {{ with $seo.translations }}
   {{ range . }}
     {{ $attr := dict "rel" "alternate" "href" .permalink "hreflang" .code }}


### PR DESCRIPTION
In compliance with Google specification, we add an additional hreflang tag for the language currently rendered. See https://developers.google.com/search/docs/specialty/international/localized-versions?hl=de