### PR TITLE
Use full xhtml schema as required by Google

### DIFF
--- a/hugo-modules/core/layouts/sitemap.xml
+++ b/hugo-modules/core/layouts/sitemap.xml
@@ -1,0 +1,40 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<!-- <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="https://www.w3.org/1999/xhtml"> -->
+<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="https://www.w3.org/1999/xhtml" xsi:schemaLocation="https://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd https://www.w3.org/1999/xhtml https://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd">
+  {{ range .Data.Pages }}
+
+    {{/* Get pages excluded from indexing by Contentful */}}
+    {{ $no_index := false }}
+    {{ with .Params.seo }}
+      {{ $seo := partial "utils/get-data" . }}
+      {{ $no_index = $seo.no_index }}
+    {{ end }}
+
+    {{/* Get page templates that are on the blocklist and should generally not be indexed */}}
+    {{ $blocked := false }}
+    {{ with .Params.sys.content_type }}
+      {{ $blocked = in site.Params.seo_blocklist . }}
+    {{ end }}
+
+    {{ if and .Permalink (not $no_index) (not $blocked) }}
+      <url>
+        <loc>{{ .Permalink }}</loc>
+        {{ if not .Lastmod.IsZero }}
+          <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>
+        {{ end }}
+        {{ with .Sitemap.ChangeFreq }}
+          <changefreq>{{ . }}</changefreq>
+        {{ end }}
+        {{ if ge .Sitemap.Priority 0.0 }}
+          <priority>{{ .Sitemap.Priority }}</priority>
+        {{ end }}
+        {{ if .IsTranslated }}
+          {{ range .Translations }}
+            <xhtml:link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" />
+          {{ end }}
+          <xhtml:link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" />
+        {{ end }}
+      </url>
+    {{ end }}
+  {{ end }}
+</urlset>

--- a/hugo-modules/core/layouts/sitemap.xml
+++ b/hugo-modules/core/layouts/sitemap.xml
@@ -9,13 +9,7 @@
       {{ $no_index = $seo.no_index }}
     {{ end }}
 
-    {{/* Get page templates that are on the blocklist and should generally not be indexed */}}
-    {{ $blocked := false }}
-    {{ with .Params.sys.content_type }}
-      {{ $blocked = in site.Params.seo_blocklist . }}
-    {{ end }}
-
-    {{ if and .Permalink (not $no_index) (not $blocked) }}
+    {{ if and .Permalink (not $no_index) }}
       <url>
         <loc>{{ .Permalink }}</loc>
         {{ if not .Lastmod.IsZero }}

--- a/hugo-modules/core/layouts/sitemap.xml
+++ b/hugo-modules/core/layouts/sitemap.xml
@@ -1,6 +1,5 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
-<!-- <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="https://www.w3.org/1999/xhtml"> -->
-<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="https://www.w3.org/1999/xhtml" xsi:schemaLocation="https://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd https://www.w3.org/1999/xhtml https://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd">
+<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="https://www.w3.org/1999/xhtml" xsi:schemaLocation="https://www.w3.org/1999/xhtml https://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd">
   {{ range .Data.Pages }}
 
     {{/* Get pages excluded from indexing by Contentful */}}


### PR DESCRIPTION
While our sitemap validates without issues in most XML validators, the Google Search Console correctly reports an esoteric error with the namespacing (as rendered by Hugo).

Roughly: Our xmlns namespace requires all non-standard elements (like xhtml:link) to be declared in a schema instance namespace. Detailed explanation [here](https://issues.liferay.com/browse/LPS-76244). Even Google themselves do not declare namespace correctly in a [tutorial](https://developers.google.com/search/docs/specialty/international/localized-versions).

This PR adds the required namespace information plus a noindex-nofollow fix from one of our projects.
