### PR TITLE
Fix: change path to Uppercase

### DIFF
--- a/packages/contentful-apps/redirects/src/locations/EntryEditor.tsx
+++ b/packages/contentful-apps/redirects/src/locations/EntryEditor.tsx
@@ -9,7 +9,7 @@ import {
   Table,
 } from '../components'
 import { Redirect } from '../types'
-import { arrayMove, countSlashes } from '../utils'
+import { arrayMove, countSlashes } from '../Utils'
 
 const Field = (): ReactElement => {
   const [redirects = [], setRedirects] = useFieldValue<Redirect[]>('redirects')


### PR DESCRIPTION
The build of the redirect app failed. Changing the file to lowercase is not tracked by github. Therefore I changed the import to the file.
