### PR TITLE
Fix: Add missing playsinline attr to video asset util

### DIFF
--- a/hugo-modules/core/utils/asset/video.html
+++ b/hugo-modules/core/utils/asset/video.html
@@ -3,12 +3,13 @@
   Render Contentful asset (video/...). Uses data from cssg-plugin-assets if available.
 
   @example - Go Template
-    {{- partial "utils/asset/svg" (dict
+    {{- partial "utils/asset/video" (dict
       "context" $video
       "options" (dict
         "loop" "false"
         "muted" "false"
         "autoplay" "false"
+        "playsinline" "false"
         "class_name" "c-video"
       )
     ) -}}
@@ -35,6 +36,7 @@
 {{- $attributes := partialCached "utils/html/attribute" (dict
   "loop" $loop
   "autoplay" $autoplay
+  "playsinline" $playsinline
   "muted" $muted
   "controls" $controls
   "class" $class_name


### PR DESCRIPTION
The `playsinline` param exists, but is not used in the `<video>`.