### PR TITLE
feature: adjust validation of redirects app

### DIFF
--- a/packages/contentful-apps/redirects/src/components/Form.tsx
+++ b/packages/contentful-apps/redirects/src/components/Form.tsx
@@ -26,6 +26,7 @@ type FormProps = {
 const Form = ({ formRef, redirect }: FormProps): ReactElement => {
   const [formData, setFormData] = useState(redirect || DEFAULT_FORM_VALUES)
   const [errors, setErrors] = useState(DEFAULT_FORM_ERRORS)
+  const [warning, setWarning] = useState(false)
 
   const fromRef = useRef() as MutableRefObject<HTMLInputElement>
   const toRef = useRef() as MutableRefObject<HTMLInputElement>
@@ -62,6 +63,10 @@ const Form = ({ formRef, redirect }: FormProps): ReactElement => {
   ): void => {
     const { name, value } = event.target
 
+    if (name === 'status' && value === '301') {
+      setWarning(true);
+    }
+
     setFormData({ ...formData, [name]: value })
     setErrors({ ...errors, [name]: error })
   }
@@ -87,6 +92,11 @@ const Form = ({ formRef, redirect }: FormProps): ReactElement => {
         getError={(value: string) => validateTo(value)}
       />
       <StatusFormControl value={formData.status} onChange={handleChange} />
+      {warning && (
+        <p style={{ color: '#bf2600' }}>
+          Warning! You're about to create a permanent redirect.
+        </p>
+      )}
     </CForm>
   )
 }

--- a/packages/contentful-apps/redirects/src/constants.ts
+++ b/packages/contentful-apps/redirects/src/constants.ts
@@ -20,7 +20,7 @@ export const DEFAULT_FORM_ERRORS: FormErrors = {
 }
 
 export const FROM_REGEX =
-  /^\/([-a-zA-Z0-9@:%._\+~#=\/]*?(\/\*)?|\*?)(\s\w+=:\w+)*?$/
+  /^\/(?!$)(([-a-zA-Z0-9@:%._\+~#=]\/?)*?(\/\*)?|\*?)(\s\w+=:\w+)*?$/
 
 export const TO_REGEX =
   /^(https?:\/\/[.\w]+(:\d+)?|\/)[-a-zA-Z0-9@:%._\+~#=\/]*?$/


### PR DESCRIPTION
This PR changes the validation regex and adds a warning if 301 (permanent redirect) is added. 
The validation regex for the from field disallows redirects from the home ("/"). That's a redirect you would not want an editor to add.