### PR TITLE
feature: allow & and ? in redirects input field

### DIFF
--- a/packages/contentful-apps/redirects/src/constants.ts
+++ b/packages/contentful-apps/redirects/src/constants.ts
@@ -20,9 +20,9 @@ export const DEFAULT_FORM_ERRORS: FormErrors = {
 }
 
 export const FROM_REGEX =
-  /^\/(?!$)(([-a-zA-Z0-9@:%._\+~#=]\/?)*?(\/\*)?|\*?)(\s\w+=:\w+)*?$/
+  /^\/(?!$)(([-a-zA-Z0-9@:%?&._\+~#=]\/?)*?(\/\*)?|\*?)(\s\w+=:\w+)*?$/
 
 export const TO_REGEX =
-  /^(https?:\/\/[.\w]+(:\d+)?|\/)[-a-zA-Z0-9@:%._\+~#=\/]*?$/
+  /^(https?:\/\/[.\w]+(:\d+)?|\/)[-a-zA-Z0-9@:%&?._\+~#=\/]*?$/
 
 export const SLASH_REGEX = /\//g


### PR DESCRIPTION
The regex may be a little bit too restrict since `&` and `?` are valid url parameter and might be needed for a redirect - for example in a campaign with tracking or something similar. 